### PR TITLE
forceltr: Optimisation and clean up

### DIFF
--- a/pathoschild.forceltr.js
+++ b/pathoschild.forceltr.js
@@ -3,31 +3,31 @@
 var pathoschild = pathoschild || {};
 (function() {
 	"use strict";
+
 	/**
 	 * Forces MediaWiki into displaying text in left-to-right format, even if the wiki's primary language is right-to-left.
 	 * @see https://github.com/Pathoschild/Wikimedia-contrib#readme
 	 */
 	pathoschild.ForceLtr = {
-		version:'0.9.0',
+		version: '0.9.1',
 
 		/**
 		 * Initialize the script.
 		 */
 		Initialize: function() {
-			/* swap load.php to an LTR language */
-			if ($('html:first').attr('dir') === 'rtl') {
-				var $links = $('link[rel="stylesheet"]');
-				$links = $links.filter('[href^="' + mw.config.get('wgLoadScript') + '"]');
-				$links.each(function(i, item) {
-					var $item = $(item);
-					$item.attr('href', $item.attr('href').replace(/&lang=[^&]+/, '&lang=en'));
-				});
-			}
+			if ($('body').hasClass('sitedir-rtl')) {
+				// Swap load.php to an LTR language
+				$('link[rel="stylesheet"][href^="' + mw.config.get('wgLoadScript') + '"]')
+					.attr('href', function(i, val) {
+						return val.replace(/&lang=[^&]+/, '&lang=en');
+					});
 
-			/* swap dir values */
-			$('*[dir="rtl"]').attr('dir', 'ltr');
+				// Swap direction
+				$('body').removeClass('rtl').addClass('ltr');
+				$('[dir="rtl"]').attr('dir', 'ltr');
+			}
 		}
 	};
 
-	$(function() { pathoschild.ForceLtr.Initialize(); });
+	$(pathoschild.ForceLtr.Initialize);
 }());


### PR DESCRIPTION
- Use 'html' instead of html:first. ":first" is a proprietary jQuery selector
  which means it initialised all of Sizzle (:first-child would be better).
  But in this case it doesn't make sense as there can only be one <html>.
- Chain jQuery methods $foo.bar().quux() instead of $foo.bar(); $foo.quux();
- Use .attr() instead of .each() + attr() + attr().
  .attr() already iterated over "all" elements in the collection and
  supports a callback to allow dynamically setting the new value based on
  the current value.
  
  This saves a loop and 2 jQuery calls (no extra $() and no
  extra attr() for reading/setting).
- Use '[dir]' instead of '*[dir]'
- Also swap body.sitedir-rtl and body.rtl
  add/removeClass supports space-separated values (regardless of their order).
- Pass Initialize function by reference to $() instead of creating another
  function just to call one function.
