### PR TITLE
Validate jshint and add Travis CI support

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,26 @@
+{
+	"bitwise" :true,
+	"eqeqeq": true,
+	"forin": false,
+	"immed": true,
+	"latedef": true,
+	"noarg": true,
+	"noempty": true,
+	"nonew": true,
+	"strict": true,
+	"trailing": true,
+	"undef": true,
+	"unused": true,
+	"quotmark": "single",
+
+	"browser": true,
+	"loopfunc": true,
+	"laxbreak": true,
+	"smarttabs": true,
+
+	"predef": [
+		"mw",
+		"$",
+		"prompt"
+	]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - 0.8
+before_script:
+  - "git submodule update --init"
+  - "npm install -g jshint"
+script:
+  - "jshint ."

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
+[![Build Status](https://travis-ci.org/Pathoschild/Wikimedia-contrib.png)](https://travis-ci.org/Pathoschild/Wikimedia-contrib)
+# Wikimedia-contrib
 **Wikimedia-contrib** is a collection of scripts intended for users of Wikimedia Foundation wikis.
 
-#### TemplateScript
+## TemplateScript
 [TemplateScript](https://meta.wikimedia.org/wiki/User:Pathoschild/Scripts/TemplateScript) adds a menu of configurable templates and scripts to the sidebar. It automatically handles templates for various forms (from editing to protection), edit summaries, auto-submission, and filtering which templates are shown based on namespace, form, or arbitrary conditions. Templates can be inserted at the cursor position or at a preconfigured position, and scripts can be invoked when a sidebar link is activated.
 
 TemplateScript is also used as a framework for other scripts, and includes a [fully-featured regex editor](https://meta.wikimedia.org/wiki/User:Pathoschild/Scripts/TemplateScript#Regex_editor) (which has a [live demo](https://toolserver.org/~pathoschild/regextoy/)) as an example.
 
-#### ForceLTR
+## ForceLTR
 [ForceLTR](https://meta.wikimedia.org/wiki/User:Pathoschild/Scripts/Force_ltr) forces MediaWiki into displaying text in left-to-right format, even if the wiki's primary language is right-to-left.
 
-#### StewardScript
+## StewardScript
 [StewardScript](https://meta.wikimedia.org/wiki/User:Pathoschild/Scripts/StewardScript) extends the user interface for [Wikimedia stewards](https://meta.wikimedia.org/wiki/Stewards)' convenience. It extends the sidebar (with links to steward pages), [Special:Block](https://meta.wikimedia.org/wiki/Special:Block) (with links to [stalktoy](https://toolserver.org/~pathoschild/stalktoy/) and [Special:CentralAuth](https://meta.wikimedia.org/wiki/Special:CentralAuth) if preloaded with a target), [Special:CentralAuth](https://meta.wikimedia.org/wiki/Special:CentralAuth) (with links to external tools, one-click status selection, a preselected template reason, and convenience links in the 'local accounts' list), and [Special:UserRights](https://meta.wikimedia.org/wiki/Special:UserRights) (with template summaries).
 
-#### Synchbot
+## Synchbot
 [Synchbot](https://meta.wikimedia.org/wiki/User:Pathoschild/Scripts/Synchbot) synchronises user pages across Wikimedia projects in every language. This allows users to create user pages on every wiki, or to have global JavaScript and CSS. (Due to the potential for misuse, this bot is not open-source.)

--- a/pathoschild.forceltr.js
+++ b/pathoschild.forceltr.js
@@ -1,8 +1,6 @@
-﻿/*jshint bitwise:true, eqeqeq:true, forin:false, immed:true, latedef:true, loopfunc:true, noarg:true, noempty:true, nonew:true, smarttabs:true, strict:true, trailing:true, undef:true*/
-/*global $:true, mw:true*/
-var pathoschild = pathoschild || {};
+﻿var pathoschild = pathoschild || {};
 (function() {
-	"use strict";
+	'use strict';
 
 	/**
 	 * Forces MediaWiki into displaying text in left-to-right format, even if the wiki's primary language is right-to-left.

--- a/pathoschild.regexeditor.js
+++ b/pathoschild.regexeditor.js
@@ -9,12 +9,11 @@ For more information, see <https://github.com/Pathoschild/Wikimedia-contrib#read
 
 
 */
-/*jshint bitwise:true, eqeqeq:true, forin:false, immed:true, latedef:true, loopfunc:true, noarg:true, noempty:true, nonew:true, smarttabs:true, strict:true, trailing:true, undef:true*/
-/*global $:true, pathoschild:true*/
 /// <reference path="pathoschild.util.js" />
 var pathoschild = pathoschild || {};
 (function () {
-	"use strict";
+	'use strict';
+
 	/**
 	 * Singleton that lets the user define custom regular expressions using a dynamic form and execute them against the text.
 	 * @author Pathoschild
@@ -380,7 +379,6 @@ var pathoschild = pathoschild || {};
 			pathoschild.util.storage.Write('tsre-sessions.' + sessionName, patterns);
 
 			// update list
-			var $list = $('.tsre-session-buttons select:first');
 			this.PopulateSessionList();
 		},
 

--- a/pathoschild.stewardscript.js
+++ b/pathoschild.stewardscript.js
@@ -1,9 +1,7 @@
-﻿/*jshint bitwise:true, eqeqeq:true, forin:false, immed:true, latedef:true, loopfunc:true, noarg:true, noempty:true, nonew:true, smarttabs:true, strict:true, trailing:true, undef:true*/
-/*global mw */
-var pathoschild = pathoschild || {};
+﻿var pathoschild = pathoschild || {};
 
 (function() {
-	"use strict";
+	'use strict';
 	/**
 	 * Extends the user interface for Wikimedia stewards' convenience.
 	 * @see https://github.com/Pathoschild/Wikimedia-contrib#readme
@@ -12,7 +10,6 @@ var pathoschild = pathoschild || {};
 		version: '2.2.1',
 	
 		Initialize: function() {
-			var _this = pathoschild.StewardScript;
 			var articleUrl = mw.config.get('wgServer') + mw.config.get('wgArticlePath');
 
 			mw.util.addCSS(
@@ -113,11 +110,9 @@ var pathoschild = pathoschild || {};
 
 					/* references & data */
 					var user  = pathoschild.StewardScript.user = $('#bodyContent input[name="target"]').val();
-					var token = $('#bodyContent input[name="wpEditToken"]')[0].value;
 
 					var $caReason = $('#bodyContent input[name="wpReason"]');
 					var $form   = $caReason.closest('form');
-					var $submit = $form.find('input[type="submit"]');
 				
 					/*****************
 					** See-also links
@@ -204,7 +199,6 @@ var pathoschild = pathoschild || {};
 						var domain = $link.text();
 						if(!domain)
 							return;
-						var $checkuserStatus = this.Make('span');
 					
 						$row.append(this
 							.Make('td')

--- a/pathoschild.templatescript.js
+++ b/pathoschild.templatescript.js
@@ -6,12 +6,11 @@ For more information, see <https://github.com/Pathoschild/Wikimedia-contrib#read
 
 
 */
-/*jshint bitwise:true, eqeqeq:true, forin:false, immed:true, latedef:true, loopfunc:true, noarg:true, noempty:true, nonew:true, smarttabs:true, strict:true, trailing:true, undef:true*/
-/*global $:true, mw:true*/
 /// <reference path="pathoschild.util.js" />
 var pathoschild = pathoschild || {};
 (function() {
-	"use strict";
+	'use strict';
+
 	if (pathoschild.TemplateScript)
 		return; // already initialized, don't overwrite
 

--- a/pathoschild.util.js
+++ b/pathoschild.util.js
@@ -7,11 +7,10 @@ For more information, see <https://github.com/Pathoschild/Wikimedia-contrib#read
 
 
 */
-/*jshint bitwise:true, eqeqeq:true, forin:false, immed:true, latedef:true, loopfunc:true, noarg:true, noempty:true, nonew:true, smarttabs:true, strict:true, trailing:true, undef:true*/
-/*global $:true, mw:true*/
 var pathoschild = pathoschild || {};
 (function () {
-	"use strict";
+	'use strict';
+
 	/**
 	 * Self-contained utility methods.
 	 * @namespace
@@ -100,7 +99,7 @@ var pathoschild = pathoschild || {};
 		 */
 		Log: function (message) {
 			if (window.console && window.console.log)
-				console.log(message);
+				window.console.log(message);
 			else if(window.mw)
 				mw.log(message);
 		},


### PR DESCRIPTION
<em>This pull is based on and includes #11 to avoid merge conflicts. Once #11 is merged, this will automatically appear as a single-commit pull.</em>

Moved all jshint options to the .jshintrc file.

This way editors with jshint-plugins pick it up, and we can also use node-jshint on the command line to lint all files at once.

---

To use jshint locally: install nodejs and `npm install -g jshint`. Then run `jshint .` or `jshint [path or file]`.

See also: http://jshint.com/platforms/#text-editor-plugins

To make the Travis CI stuff work, you need to enable it in your account (only takes a few seconds):

http://about.travis-ci.org/docs/user/getting-started/#Step-one%3A-Sign-in
