### PR TITLE
adjust exceptions code to match additional reqs

### DIFF
--- a/tool-labs/accounteligibility/index.php
+++ b/tool-labs/accounteligibility/index.php
@@ -3412,7 +3412,7 @@ while ($script->user['name'] && !$cached) {
 			if(isset($script->event['exceptions'])) {
 				echo '<div class="neutral"><strong>This account might be eligible if it fits rule exceptions that cannot be checked by this script:<ul style="margin:0;">';
 				foreach ($script->event['exceptions'] as $exc)
-					echo '<li>{$exc}</li>';
+					echo '<li>', $exc, '</li>';
 				echo '</ul></div>';
 			}
 			if(isset($script->event['warn_ineligible']))


### PR DESCRIPTION
Thanks for the quick deploy (and the fixes ;) ) with the elections patch. The regular check seems to be working perfectly but when an account isn't eligible the exceptions aren't showing correctly (they just show up as 4 {$exc} see https://tools.wmflabs.org/meta/accounteligibility/36/Jamesofur_Public ). The 2011 election (the only other one with exceptions that I can see) seems to have the same issue so I'm thinking it's in that part of the code. I'm not 100% sure if this patch will fix that but since the more_reqs script above it works well I adjusted to match with the idea that might do it and there was just some php changes since then to make not like the old format.