### PR TITLE
load jQuery from cdnjs mirror at WMF Labs

### DIFF
--- a/tool-labs/backend/modules/Backend.php
+++ b/tool-labs/backend/modules/Backend.php
@@ -172,7 +172,7 @@ class Backend extends Base {
 		<title>', $this->title, '</title>
 		<link rel="shortcut icon" href="', $this->url('/content/favicon.ico'), '" />
 		<link rel="stylesheet" type="text/css" href="', $this->url('/content/stylesheet.css'), '" />
-		<script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
+		<script src="//tools-static.wmflabs.org/cdnjs/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
 		<script src="', $this->url('/content/jquery.collapse/jquery.collapse.js'), '" type="text/javascript"></script>
 		<script src="', $this->url('/content/main.js'), '" type="text/javascript"></script>
 		', $this->hook_head, '

--- a/tool-labs/iso639db/parseIso639Codes.js
+++ b/tool-labs/iso639db/parseIso639Codes.js
@@ -17,7 +17,7 @@ pathoschild.ParseIso639Codes = {
 	ImportJquery: function() {
 		var head = document.getElementsByTagName('head')[0];
 		var script = document.createElement('script');
-		script.setAttribute('src', 'http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.js');
+		script.setAttribute('src', '//tools-static.wmflabs.org/cdnjs/ajax/libs/jquery/1.7.1/jquery.min.js');
 		script.setAttribute('type', 'text/javascript');
 		head.appendChild(script);
 	},


### PR DESCRIPTION
Because googleapis.com breaks the Labs Privacy Policy:
https://phabricator.wikimedia.org/T96799