### PR TITLE
Removing Special:GlobalRenameRequest

### DIFF
--- a/user-scripts/pathoschild.stewardscript.js
+++ b/user-scripts/pathoschild.stewardscript.js
@@ -56,7 +56,6 @@
 				{name:'user > rights (local)', page:'Special:UserRights', desc:'Manage local user rights'},
 				{name:'user > rights (global)', page:'Special:GlobalGroupMembership', desc:'Manage global user rights'},
 				{name:'user > global rename', page:'Special:GlobalRenameUser', desc:'Globally rename users'},
-				{name:'global rename request', page:'Special:GlobalRenameRequest', desc:'Global rename request form'},
 				{name:'global rename queue', page:'Special:GlobalRenameQueue/open', desc:'Global rename processing queue'},
 				{name:'IP > global block', page:'Special:GlobalBlock', desc:'Globally block an IP'},
 				{name:'IP > global unblock', page:'Special:GlobalUnblock', desc:'Globally unblock an IP'},


### PR DESCRIPTION
Form is for self-requested rename requests which stewards are unlikely to be using.