### PR TITLE
StewardryEngine: add interface-admin, tweak logs for others

### DIFF
--- a/tool-labs/stewardry/framework/StewardryEngine.php
+++ b/tool-labs/stewardry/framework/StewardryEngine.php
@@ -12,8 +12,9 @@ class StewardryEngine extends Base
      * @var array
      */
     public $presetGroups = [
-        'sysop' => ['abusefilter', 'block', 'delete', 'protect'],
-        'bureaucrat' => ['makebot', 'renameuser', 'rights'],
+        'sysop' => ['abusefilter', 'block', 'delete', 'protect', 'rights'],
+        'bureaucrat' => ['rights'],
+        'interface-admin' => [],
         'checkuser' => [],
         'oversight' => [],
         'bot' => []


### PR DESCRIPTION
* Add support for the new 'interface-admin' permission.
* Administrators can in WMF wikis can add and remove some permissions (ipblock-exempt, etc.). Add right log query for them as well given that it is admin activity.
* Remove 'makebot' log search for bureaucrats given that such log ceased to exist ages ago (like 'makesysop').
* Remove 'renameuser' log search for bureaucrats given that bureaucrats at WMF wikis lost the ability to locally rename users years ago. Willing to keep it added for backwards compatibility if needed.