### PR TITLE
stalktoy: Use Wikimedia Toolforge "whois"

### DIFF
--- a/tool-labs/stalktoy/index.php
+++ b/tool-labs/stalktoy/index.php
@@ -125,7 +125,7 @@ if ($engine->isValid() && $ip->ip->isValid()) {
     echo "
         <div>
             Related toys:
-            <a href='https://www.whois.com/whois/", $ip->ip->getFriendly(), "' title='whois query'>whois</a>,
+            <a href='https://whois.toolforge.org/gateway.py?lookup=true&ip=", $ip->ip->getFriendly(), "' title='whois query'>whois</a>,
             <a href='https://meta.wikimedia.org/wiki/Special:GlobalBlock?wpAddress={$engine->targetWikiUrl}' title='Special:GlobalBlock'>global block</a>.
         </div>
         ";


### PR DESCRIPTION
Change the WHOIS provider to use https://whois.toolforge.org instead which is more straightforward and privacy-friendly (e.g. hosted in WMF servers, no reCAPTCHA, no ads, etc.).