### PR TITLE
Remove Special:GlobalUserRights link in stewardscript

### DIFF
--- a/user-scripts/pathoschild.stewardscript.js
+++ b/user-scripts/pathoschild.stewardscript.js
@@ -145,12 +145,6 @@
                                 .text("crossactivity")
                                 .attr({ href: "https://meta.toolforge.org/crossactivity/" + encodeURIComponent(user), title: "Pathoschild's CrossActivity (measures a user's latest edit, bureaucrat, or sysop activity on all wikis)" })
                             )
-                            .append(", ")
-                            .append(this
-                                .Make("a")
-                                .text("global user rights")
-                                .attr({ href: "https://meta.wikimedia.org/wiki/Special:GlobalUserRights/" + encodeURIComponent(user), title: "Global User Rights" })
-                            )
                         );
 
                     /*****************


### PR DESCRIPTION
This reverts commit: https://github.com/Pathoschild/Wikimedia-contrib/commit/588f81d71d950d317812aed6b436a39e98bdc1d2

See also: https://github.com/Pathoschild/Wikimedia-contrib/issues/129 and https://github.com/Pathoschild/Wikimedia-contrib/pull/130

Reason for revert: this functionality is now included in CentralAuth itself (see https://github.com/wikimedia/mediawiki-extensions-CentralAuth/commit/af6016dbf31d0105ca6ccad8c80ffd1795770a1c)

Fixes: #145 