### PR TITLE
accounteligibility: Add SE2021

### DIFF
--- a/tool-labs/accounteligibility/framework/EventFactory.php
+++ b/tool-labs/accounteligibility/framework/EventFactory.php
@@ -23,6 +23,28 @@ class EventFactory
     public function getEvents()
     {
         ##########
+        ## 2021: steward elections
+        ##########
+        // voters
+        yield (new Event(55, 2021, 'steward elections', 'https://meta.wikimedia.org/wiki/Stewards/Elections_2021'))
+            ->addRule(new NotBotRule(), Workflow::HARD_FAIL)
+            ->addRule(new EditCountRule(600, null, '<202011', EditCountRule::ACCUMULATE))// 600 edits before 01 November 2020
+            ->addRule(new EditCountRule(50, '202008', '<202102', EditCountRule::ACCUMULATE));// 50 edits between 01 August 2020 and 31 January 2021
+
+        // candidates
+        yield (new Event(54, 2021, 'steward elections (candidates)', 'https://meta.wikimedia.org/wiki/Stewards/Elections_2021'))
+        ->addRule(new NotBotRule(), Workflow::HARD_FAIL)
+        ->addRule(new EditCountRule(600, null, '<202011', EditCountRule::ACCUMULATE))// 600 edits before 01 November 2020
+        ->addRule(new EditCountRule(50, '202008', '<202102', EditCountRule::ACCUMULATE))// 50 edits between 01 August 2020 and 31 January 2021
+        ->addRule(new HasGroupDurationRule('sysop', 90, '<202102081400'), Workflow::ON_ANY_WIKI)// flagged as a sysop for three months
+        ->withAction('<strong>be a candidate</strong>')
+        ->withExtraRequirements([
+            'You must be 18 years old, and at the age of majority in your country.',
+            'You must agree to abide by the policies governing <a href="https://meta.wikimedia.org/wiki/Stewards_policy" title="Steward policy">steward access</a>, <a href="https://meta.wikimedia.org/wiki/CheckUser_policy" title="checkuser policy">checkuser access</a>, <a href="https://meta.wikimedia.org/wiki/Oversight_policy" title="oversight policy">oversight access</a>, and <a href="https://foundation.wikimedia.org/wiki/Privacy_policy" title="privacy policy">privacy</a>.',
+            'You must <a href="https://meta.wikimedia.org/wiki/Special:MyLanguage/Access_to_nonpublic_personal_data_policy" title="Access to nonpublic personal data policy">sign the confidentiality agreement</a>.'
+        ]);
+
+        ##########
         ## 2020: Commons Picture of the Year for 2019
         ##########
         yield (new Event(53, 2020, 'Commons Picture of the Year for 2019', 'https://commons.wikimedia.org/wiki/Commons:Picture_of_the_Year/2019'))


### PR DESCRIPTION
See https://meta.wikimedia.org/wiki/Stewards/Elections_2021/Guidelines for canonical election requirements.