### PR TITLE
New event with multiple wikis

### DIFF
--- a/tool-labs/accounteligibility/framework/AccountEligibilityEngine.php
+++ b/tool-labs/accounteligibility/framework/AccountEligibilityEngine.php
@@ -210,7 +210,7 @@ class AccountEligibilityEngine extends Base
 
     /**
      * Load the queue of wikis to analyse.
-     * @param string|null $default The default wiki.
+     * @param string|string[]|null $default The default wiki.
      * @param int $minEdits The minimum number of edits.
      * @return bool Whether at least one wiki was successfully loaded.
      */
@@ -224,6 +224,12 @@ class AccountEligibilityEngine extends Base
             $this->nextQueueIndex = 0;
             $this->msg("Selected {$this->wiki->domain}.", 'is-metadata');
         }
+
+		elseif (is_array($default)) {
+			$this->queue = array_values($default);
+			$this->nextQueueIndex = 0;
+			$this->msg('Selected ' . implode(', ', $default) . '.', 'is-metadata');
+		}
 
         ########
         ## Set single wiki

--- a/tool-labs/accounteligibility/framework/EventFactory.php
+++ b/tool-labs/accounteligibility/framework/EventFactory.php
@@ -23,6 +23,16 @@ class EventFactory
     public function getEvents()
     {
         ##########
+        ## 2021: WMDE TechWishes survey https://phabricator.wikimedia.org/T285475
+        ##########
+        yield (new Event(57, 2021, 'Kleine Umfragen Technische Wünsche', 'https://www.wikimedia.de/projects/projekt-technische-wuensche/'))
+            ->addRule(new NotBlockedRule(1), Workflow::HARD_FAIL)// not blocked on more than one wiki
+            ->addRule(new NotBotRule(), Workflow::HARD_FAIL)
+            ->addRule(new DateRegisteredRule('<20210619'), Workflow::ON_ANY_WIKI)// registered before 19 June 2021 (30 days before survey start)
+            ->addRule(new EditCountRule(50, null, '<20210619', EditCountRule::ACCUMULATE))// 50 edits before 19 June 2021 (30 days before survey start)
+            ->withExtraRequirements(['Your account must in one of the following wikis: de-Wikipedia, de-Wikivoyage, de-Wikibooks, de-Wikiversity, de-Wiktionary, de-Wikiquote, de-Wikisource, de-Wikinews, Wikimedia Commons.']);
+
+        ##########
         ## 2021: Wikimedia Foundation elections
         ##########
         yield (new Event(56, 2021, 'Wikimedia Foundation elections', 'https://meta.wikimedia.org/wiki/Wikimedia_Foundation_elections/2021'))

--- a/tool-labs/accounteligibility/framework/EventFactory.php
+++ b/tool-labs/accounteligibility/framework/EventFactory.php
@@ -25,12 +25,22 @@ class EventFactory
         ##########
         ## 2021: WMDE TechWishes survey https://phabricator.wikimedia.org/T285475
         ##########
-        yield (new Event(57, 2021, 'Kleine Umfragen Technische Wünsche', 'https://www.wikimedia.de/projects/projekt-technische-wuensche/'))
+        yield (new Event(57, 2021, 'Kleine Umfragen Technische Wünsche', 'https://de.wikipedia.org/wiki/Wikipedia:Technische_W%C3%BCnsche/Topw%C3%BCnsche/Bessere_Unterstützung_von_Geoinformationen/Umfrage'))
             ->addRule(new NotBlockedRule(1), Workflow::HARD_FAIL)// not blocked on more than one wiki
             ->addRule(new NotBotRule(), Workflow::HARD_FAIL)
             ->addRule(new DateRegisteredRule('<20210619'), Workflow::ON_ANY_WIKI)// registered before 19 June 2021 (30 days before survey start)
-            ->addRule(new EditCountRule(50, null, '<20210619', EditCountRule::ACCUMULATE))// 50 edits before 19 June 2021 (30 days before survey start)
-            ->withExtraRequirements(['Your account must in one of the following wikis: de-Wikipedia, de-Wikivoyage, de-Wikibooks, de-Wikiversity, de-Wiktionary, de-Wikiquote, de-Wikisource, de-Wikinews, Wikimedia Commons.']);
+            ->addRule(new EditCountRule(50, null, '<20210719'))// 50 edits before the day the survey started
+			->withOnlyDB([
+				'commonswiki',
+				'dewiki',
+				'dewikibooks',
+				'dewikinews',
+				'dewikiquote',
+				'dewikisource',
+				'dewikiversity',
+				'dewikivoyage',
+				'dewiktionary',
+			]);
 
         ##########
         ## 2021: Wikimedia Foundation elections

--- a/tool-labs/accounteligibility/framework/models/Event.php
+++ b/tool-labs/accounteligibility/framework/models/Event.php
@@ -58,7 +58,7 @@ class Event
 
     /**
      * The only database name to analyse (or null to allow any wiki).
-     * @var string|null
+     * @var string|string[]|null
      */
     public $onlyDB;
 
@@ -152,7 +152,7 @@ class Event
 
     /**
      * Set the only database name to analyse.
-     * @param string $value
+     * @param string|string[] $value
      * @return $this;
      */
     public function withOnlyDB($value)


### PR DESCRIPTION
For the new event 2021 WMDE TechWishes survey in AccountEligibility we need a list of wikis instead of only a string. We added this, but could not test it fully. Would be nice if you could test it @Pathoschild. :)