### PR TITLE
stalktoy: Add bullseye tool (was stalktoy: stalktoy: Update whois tool)

### DIFF
--- a/tool-labs/stalktoy/index.php
+++ b/tool-labs/stalktoy/index.php
@@ -125,7 +125,7 @@ if ($engine->isValid() && $ip->ip->isValid()) {
     echo "
         <div>
             Related toys:
-            <a href='https://whois.toolforge.org/gateway.py?lookup=true&ip=", $ip->ip->getFriendly(), "' title='whois query'>whois</a>,
+            <a href='https://whois-referral.toolforge.org/gateway.py?lookup=true&ip=", $ip->ip->getFriendly(), "' title='whois query'>whois</a>,
             <a href='https://meta.wikimedia.org/wiki/Special:GlobalBlock?wpAddress={$engine->targetWikiUrl}' title='Special:GlobalBlock'>global block</a>.
         </div>
         ";


### PR DESCRIPTION
The WHOIS Toolforge tool used until now has a banner indicating that the same is experiencing problems. As such, let's use ST47's WHOIS which in addition to the previous functionality includes "support for querying referral DNS servers".