### PR TITLE
Rename oversight to suppress

### DIFF
--- a/tool-labs/stewardry/framework/StewardryEngine.php
+++ b/tool-labs/stewardry/framework/StewardryEngine.php
@@ -16,7 +16,7 @@ class StewardryEngine extends Base
         'bureaucrat' => ['rights'],
         'interface-admin' => [],
         'checkuser' => [],
-        'oversight' => [],
+        'suppress' => [],
         'bot' => []
     ];
 


### PR DESCRIPTION
The group was renamed on WMF wiki to match MediaWiki core's default name. See <https://phabricator.wikimedia.org/T112147> and https://github.com/wikimedia/operations-mediawiki-config/commit/800935236d9c54fc575d36b36f04b45448320f11

The repo probably needs further updates.